### PR TITLE
feat: apply Roxana color/code changes

### DIFF
--- a/components/day-view.tsx
+++ b/components/day-view.tsx
@@ -244,7 +244,7 @@ export default function DayView() {
               const topPx = roomCell ? roomCell.offsetTop : roomIndex * hourHeight;
 
               const eventColor = event.color !== "" ? event.color : "#98b8ff";
-              const darker = adjustColor(eventColor, 120);
+              const darker = eventColor;
               const lighter = adjustColor(eventColor, 150);
               const eventTextColor = getContrastColor(darker);
 

--- a/components/event-renderer.tsx
+++ b/components/event-renderer.tsx
@@ -46,7 +46,7 @@ export function EventRenderer({ date, view, events }: EventRendererProps) {
       {visibleEvents.map((event) => { 
         const eventName = event.name !== "" ? event.name : "-";
         const eventColor = event.color !== "" ? event.color : "#98b8ff"; // Default to blue if not found
-        const darker = adjustColor(eventColor, 120);
+        const darker = adjustColor(eventColor, 40);
         const lighter = adjustColor(eventColor, 150);
         const eventTextColor = getContrastColor(darker);
         const eventDuration: number = Math.abs(event.date.diff(event.endTime,'hour',true));

--- a/components/footer/ReservationLegend.tsx
+++ b/components/footer/ReservationLegend.tsx
@@ -2,9 +2,8 @@
 
 import { useFiltersStore } from "@/lib/store";
 import { useState, useEffect } from "react";
-import { adjustColor } from "@/lib/utils";
 
-type Carrera = { id: number; name: string; color: string };
+type Carrera = { id: number; code: string; name: string; color: string };
 
 export function ReservationLegend() {
   const { reservationTypes } = useFiltersStore();
@@ -66,6 +65,29 @@ export function ReservationLegend() {
             </button>
           </div>
 
+          {carreras.length > 0 && (
+            <>
+              <div className="mb-3">
+                <div className="space-y-1">
+                  {carreras.map((carrera) => (
+                    <div key={carrera.id} className="flex items-center gap-2">
+                      <div
+                        className="h-3 w-3 flex-shrink-0 rounded"
+                        style={{
+                          backgroundColor: carrera.color,
+                          border: `2px solid ${carrera.color}`,
+                        }}
+                      />
+                      <span className="truncate text-sm text-gray-600">
+                        {carrera.name}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </>
+          )}
+
           {reservationTypes.filter((type) => type.id !== 1).length > 0 && (
             <>
               <div className="mb-3">
@@ -78,35 +100,12 @@ export function ReservationLegend() {
                       <div
                         className="h-3 w-3 flex-shrink-0 rounded"
                         style={{
-                          backgroundColor: adjustColor(type.color, 120),
+                          backgroundColor: type.color,
                           border: `2px solid ${type.color}`,
                         }}
                       />
                       <span className="truncate text-sm text-gray-600">
                         {type.name}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </>
-          )}
-
-          {carreras.length > 0 && (
-            <>
-              <div className="border-t pt-3">
-                <div className="space-y-1">
-                  {carreras.map((carrera) => (
-                    <div key={carrera.id} className="flex items-center gap-2">
-                      <div
-                        className="h-3 w-3 flex-shrink-0 rounded"
-                        style={{
-                          backgroundColor: adjustColor(carrera.color, 120),
-                          border: `2px solid ${carrera.color}`,
-                        }}
-                      />
-                      <span className="truncate text-sm text-gray-600">
-                        {carrera.name}
                       </span>
                     </div>
                   ))}


### PR DESCRIPTION
- DayView: use raw event color instead of adjustColor(120)
- EventRenderer: darken level 120 -> 40 for richer event bars
- ReservationLegend: add 'code' to Carrera type, reorder sections (carreras first), use raw colors in swatches